### PR TITLE
Update keep-alive for multi-tenant use, and storeToken where id when using tenant_id in the class

### DIFF
--- a/src/Console/Commands/XeroKeepAliveCommand.php
+++ b/src/Console/Commands/XeroKeepAliveCommand.php
@@ -3,6 +3,7 @@
 namespace Dcblogdev\Xero\Console\Commands;
 
 use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Models\XeroToken;
 use Illuminate\Console\Command;
 
 class XeroKeepAliveCommand extends Command
@@ -12,8 +13,17 @@ class XeroKeepAliveCommand extends Command
 
     public function handle()
     {
-        if (Xero::isConnected()) {
-            Xero::getAccessToken($redirectWhenNotConnected = false);
+        // Fetch all tenants for when multiple tenants are in use.
+        $tenants    = XeroToken::all();
+
+        foreach($tenants as $tenant) {
+
+            // Set the tenant ID
+            Xero::setTenantId($tenant->id);
+
+            if (Xero::isConnected()) {
+                Xero::getAccessToken($redirectWhenNotConnected = false);
+            }
         }
     }
 }

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -155,7 +155,7 @@ class Xero
         // Check if token is expired
         // Get current time + 5 minutes (to allow for time differences)
         $now = time() + 300;
-        if ($token->expires <= $now) {
+        if ($token->expires_in <= $now) {
             // Token is expired (or very close to it) so let's refresh
 
             $params = [

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -244,7 +244,9 @@ class Xero
             'scopes'        => $token['scope']
         ];
 
-        if ($tenantData != null) {
+        if($this->tenant_id) {
+            $where = ['id' => $this->tenant_id];
+        } else if ($tenantData != null) {
             $data  = array_merge($data, $tenantData);
             $where = ['tenant_id' => $data['tenant_id']];
         } else {


### PR DESCRIPTION
This just now fetches all tenants to run a refresh, in theory if one person is using multiple tenants we could just use the same tokens but this approach covers all use cases and is the easiest method. 