### PR TITLE
WIP: feat: upgrade to use Laravel Http wrapper for testability / mocking

### DIFF
--- a/src/Models/XeroToken.php
+++ b/src/Models/XeroToken.php
@@ -2,9 +2,19 @@
 
 namespace Dcblogdev\Xero\Models;
 
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 class XeroToken extends Model
 {
     protected $guarded = [];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute<Carbon, never>
+     */
+    protected function expires(): Attribute
+    {
+        return Attribute::get(fn(): Carbon => $this->updated_at->addSeconds($this->expires_in));
+    }
 }


### PR DESCRIPTION
Instead of guzzle allow the package to use Laravels Http Wrapper,  (laravel 8 & 9) 
this is tidier and allows for easier mocking in application based testing.

Additionally changed time to now to allow` Carbon::setTestNow(` to affect the expiry time

eg:
```
$inv = json_decode(file_get_contents(__DIR__ . '/../Snapshots/Xero/AddInvoice.json'), true);

        $http = Http::fake([
            '*' => Http::response($inv, 200),
        ]);
        
        // call function that sends invoice to Xero
        
         $calls = $http->recorded()->map(fn($call): array => json_decode($call[0]->body(), true));

        $this->assertCount(1, $calls);

        $first = $calls->first();
        $this->assertIsArray($first);
        $this->assertSame('ACCPAY', $first['Type']);
        $this->assertSame(5, $first['LineItems'][0]['UnitAmount']);
        $this->assertSame('uuid-9000', $first['Contact']['ContactID']);

        ```