### PR TITLE
Add support for configurable Accept header in HTTP call 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ use Dcblogdev\Xero\Models\XeroToken;
 
 To set the tenant call `setTenantId` and pass in your tenant_id
 
-Once set all calls will use the set tenant. 
+Once set all calls will use the set tenant.
 
 ```php
 setTenantId($tenant_id)
@@ -97,7 +97,7 @@ php artisan xero:keep-alive
 This will refresh the token when its due to expire.
 Its recommended to add this to a schedule ie inside `App\Console\Kernal.php` add the command to a schedule.
 
-```php 
+```php
 protected function schedule(Schedule $schedule)
 {
     $schedule->command('xero:keep-alive')->everyFiveMinutes();
@@ -163,7 +163,7 @@ Xero::get('contacts')
 
 # Is Connected
 
-Anytime you need to check if Xero is authenticated you can call a ->isConnected method. The method returns a boolean. 
+Anytime you need to check if Xero is authenticated you can call a ->isConnected method. The method returns a boolean.
 
 To do an action when a Xero is not connected can be done like this:
 
@@ -345,6 +345,14 @@ See https://developer.xero.com/documentation/api/invoices#post for details on th
 
 ```php
 Xero::invoices()->update($invoiceId, $data);
+```
+
+## PDF resources
+Some Xero resources support being downloaded as PDF. To do this you can:
+
+```php
+$pdfInvoice = Xero::get("invoices/{$invoiceId}", null, true, 'application/pdf');
+$pdfInvoice['body']; // will be the pdf as a pdf string for you to write out to storage etc.
 ```
 
 ## Change log

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -264,8 +264,6 @@ class Xero
                 'Xero-tenant-id' => $this->getTenantId(),
             ])->acceptJson()->$type(self::$baseUrl . $request, $data)->throw();
 
-            dump($response->getBody()->getContents());
-
             return [
                 'body'    => $response->json(),
                 'headers' => $response->getHeaders()

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -203,9 +203,10 @@ class Xero
         $path    = (isset($args[0])) ? $args[0] : '';
         $data    = (isset($args[1])) ? $args[1] : [];
         $raw     = (isset($args[2])) ? $args[2] : false;
+        $accept  = (isset($args[3])) ? $args[3] : 'application/json';
 
         if (in_array($function, $options)) {
-            return $this->guzzle($function, $path, $data, $raw);
+            return $this->guzzle($function, $path, $data, $raw, $accept);
         } else {
             //request verb is not in the $options array
             throw new Exception($function . ' is not a valid HTTP Verb');
@@ -257,15 +258,17 @@ class Xero
      * @param  bool  $raw
      * @return array
      */
-    protected function guzzle($type, $request, $data = [], $raw = false)
+    protected function guzzle($type, $request, $data = [], $raw = false, $accept = 'application/json')
     {
         try {
-            $response = Http::withToken($this->getAccessToken())->withHeaders([
-                'Xero-tenant-id' => $this->getTenantId(),
-            ])->acceptJson()->$type(self::$baseUrl . $request, $data)->throw();
+            $response = Http::withToken($this->getAccessToken())
+                ->withHeaders(['Xero-tenant-id' => $this->getTenantId()])
+                ->accept($accept)
+                ->$type(self::$baseUrl . $request, $data)
+                ->throw();
 
             return [
-                'body'    => $response->json(),
+                'body'    => $raw ? $response->body() : $response->json(),
                 'headers' => $response->getHeaders()
             ];
         } catch (RequestException $e) {


### PR DESCRIPTION
@dcblogdev 

PR #20 had a `dump()` call on the HTTP response, this removes it to prevent printing to stdout on each http call.

I also added the featured I mentioned in #20.

```php
$resp = Xero::get("invoices/{$invoiceId}", $data = null, $raw = true, $accept = 'application/pdf');
$pdfInvoiceString = $resp['body'];
```

This should be backwards compatible. I can seperate these two commits into seperate PRs if you'd prefer.