### PR TITLE
Update Xero.php to fix expiry check to use the accessor instead of co…

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -139,7 +139,7 @@ class Xero
 
         $now = now()->addMinutes(5);
 
-        if ($token->expires_in < $now) {
+        if ($token->expires < $now) {
             return $this->renewExpiringToken($token);
         }
 


### PR DESCRIPTION
…lumn value

All api calls are firing additional token renew request because of using the expires_in column instead of expires accessor attribute.