### PR TITLE
Critical Bugfix where tenant_id was checked against id column 

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -156,7 +156,7 @@ class Xero
 
         $resultCode = $this->dopost(self::$tokenUrl, $params);
 
-        $this->storeToken($resultCode, ['tenant_id' => $token->tenant_id);
+        $this->storeToken($resultCode, ['tenant_id' => $token->tenant_id]);
 
         return $resultCode['access_token'];
     }

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -125,7 +125,7 @@ class Xero
     public function getTokenData(): XeroToken|null
     {
         if ($this->tenant_id) {
-            return XeroToken::where('id', '=', $this->tenant_id)->first();
+            return XeroToken::where('tenant_id', '=', $this->tenant_id)->first();
         }
 
         return XeroToken::first();
@@ -156,7 +156,7 @@ class Xero
 
         $resultCode = $this->dopost(self::$tokenUrl, $params);
 
-        $this->storeToken($resultCode);
+        $this->storeToken($resultCode, ['tenant_id' => $token->tenant_id);
 
         return $resultCode['access_token'];
     }
@@ -229,7 +229,7 @@ class Xero
         ];
 
         if ($this->tenant_id) {
-            $where = ['id' => $this->tenant_id];
+            $where = ['tenant_id' => $this->tenant_id];
         } elseif ($tenantData !== null) {
             $data  = array_merge($data, $tenantData);
             $where = ['tenant_id' => $data['tenant_id']];


### PR DESCRIPTION
To understand current issue here is how to reproduce it.

- Connect To xero
- Disconnect
- Connect again so that your record has id > 1
- try calling xero api after the token expiry which is around 30 minutes
- Now because current code check the xero tenant id agains id (primary key) column renewing token falls back to id =1 condition and adds new token on the db
- If you disconnect once, the packgage will still think xero is connected because of the first one is still remaining
-  Also i don't know why no one has found out, if you are connecting with multiple tenants no matter what, only first token is being used.