### PR TITLE
Use DateTimeInterface for Xero token expires attribute

### DIFF
--- a/src/Models/XeroToken.php
+++ b/src/Models/XeroToken.php
@@ -2,7 +2,7 @@
 
 namespace Dcblogdev\Xero\Models;
 
-use Carbon\Carbon;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
@@ -11,12 +11,12 @@ class XeroToken extends Model
     protected $guarded = [];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute<Carbon, never>
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute<DateTimeInterface, never>
      */
     protected function expires(): Attribute
     {
         return Attribute::get(
-            fn(): Carbon => $this->updated_at->addSeconds($this->expires_in)
+            fn(): DateTimeInterface => $this->updated_at->addSeconds($this->expires_in)
         );
     }
 }


### PR DESCRIPTION
Our app has Laravel set up to use `CarbonImmutable`.

```php
Date::use(CarbonImmutable::class);
```

Because of this, `updated_at` is a `CarbonImmutable` instance which causes a type error when retrieving the `expires` attribute. This PR updates the return type to a more generic `DateTimeInterface`.