### PR TITLE
Correct class inheritance for easier mockery usage

### DIFF
--- a/src/Facades/Xero.php
+++ b/src/Facades/Xero.php
@@ -4,6 +4,14 @@ namespace Dcblogdev\Xero\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static array get (string $endpoint, array $params = [])
+ * @method static array put (string $endpoint, array $params = [])
+ * @method static array post (string $endpoint, array $params = [])
+ * @method static array patch (string $endpoint, array $params = [])
+ * @method static array delete (string $endpoint, array $params = [])
+ * @mixin \Dcblogdev\Xero\Xero
+ */
 class Xero extends Facade
 {
     /**

--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -2,7 +2,7 @@
 
 namespace Dcblogdev\Xero\Resources;
 
-use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Xero;
 
 class Contacts extends Xero
 {
@@ -13,28 +13,28 @@ class Contacts extends Xero
             'where' => $where
         ]);
 
-        $result = Xero::get('contacts?'.$params);
+        $result = $this->get('contacts?'.$params);
 
         return $result['body']['Contacts'];
     }
 
     public function find(string $contactId)
     {
-        $result = Xero::get('contacts/'.$contactId);
+        $result = $this->get('contacts/'.$contactId);
 
         return $result['body']['Contacts'][0];
     }
 
-    public function update(string $contactId, array $data) 
+    public function update(string $contactId, array $data)
     {
-        $result = Xero::post('contacts/'.$contactId, $data);
+        $result = $this->post('contacts/'.$contactId, $data);
 
         return $result['body']['Contacts'][0];
     }
 
-    public function store(array $data) 
+    public function store(array $data)
     {
-        $result = Xero::post('contacts', $data);
+        $result = $this->post('contacts', $data);
 
         return $result['body']['Contacts'][0];
     }

--- a/src/Resources/Invoices.php
+++ b/src/Resources/Invoices.php
@@ -2,7 +2,7 @@
 
 namespace Dcblogdev\Xero\Resources;
 
-use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Xero;
 
 class Invoices extends Xero
 {
@@ -13,35 +13,35 @@ class Invoices extends Xero
             'where' => $where
         ]);
 
-        $result = Xero::get('invoices?'.$params);
+        $result = $this->get('invoices?'.$params);
 
         return $result['body']['Invoices'];
     }
 
     public function find(string $contactId)
     {
-        $result = Xero::get('invoices/'.$contactId);
+        $result = $this->get('invoices/'.$contactId);
 
         return $result['body']['Invoices'][0];
     }
 
     public function onlineUrl(string $invoiceId)
     {
-        $result = Xero::get('invoices/'.$invoiceId.'/OnlineInvoice');
+        $result = $this->get('invoices/'.$invoiceId.'/OnlineInvoice');
 
         return $result['body']['OnlineInvoices'][0]['OnlineInvoiceUrl'];
     }
 
     public function update(string $invoiceId, array $data)
     {
-        $result = Xero::post('invoices/'.$invoiceId, $data);
+        $result = $this->post('invoices/'.$invoiceId, $data);
 
         return $result['body']['Invoices'][0];
     }
 
-    public function store(array $data) 
+    public function store(array $data)
     {
-        $result = Xero::post('invoices', $data);
+        $result = $this->post('invoices', $data);
 
         return $result['body']['Invoices'][0];
     }

--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -2,7 +2,7 @@
 
 namespace Dcblogdev\Xero\Resources;
 
-use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Xero;
 
 class Webhooks extends Xero
 {


### PR DESCRIPTION
I believe your resource classes should extend the actual implementations, and not the facades - they are not themselves facades. To make this work you then have to call instance methods instead of calling back to the facade.

The original way makes phpstan upset in some situations, and mockery is unable to mock the objects using demeter chains due to all of the calls within each resource that then go back round through the facade.

Tests still pass etc, seems functionally equivalent - just more correct ? But perhaps that is subjective... 

Also added the docblocks to make phpstan happy(er).