### PR TITLE
Changed filters to by fluent rather than array based

### DIFF
--- a/src/Enums/FilterOptions.php
+++ b/src/Enums/FilterOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Dcblogdev\Xero\Enums;
+
+enum FilterOptions: string {
+    case IDS = 'ids';
+    case INCLUDEARCHIVED = 'includeArchived';
+    case ORDER = 'order';
+    case PAGE = 'page';
+    case SEARCHTERM = 'searchTerm';
+    case SUMMARYONLY = 'summaryOnly';
+    case WHERE = 'where';
+
+    public static function isValid(string $value): bool
+    {
+        $validValues = array_map(fn($case) => $case->value, self::cases());
+
+        return in_array($value, $validValues);
+    }
+}

--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -2,39 +2,51 @@
 
 namespace Dcblogdev\Xero\Resources;
 
+use Dcblogdev\Xero\Enums\FilterOptions;
 use Dcblogdev\Xero\Xero;
+use InvalidArgumentException;
 
 class Contacts extends Xero
 {
-    public function get(int $page = 1, string $where = ''): array
-    {
-        $params = http_build_query([
-            'page' => $page,
-            'where' => $where
-        ]);
+    protected array $queryString = [];
 
-        $result = parent::get('contacts?'.$params);
+    public function filter($key, $value): static
+    {
+        if (! FilterOptions::isValid($key)) {
+            throw new InvalidArgumentException("Filter option '$key' is not valid.");
+        }
+
+        $this->queryString[$key] = $value;
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        $queryString = $this->formatQueryStrings($this->queryString);
+
+        $result = parent::get('Contacts?'.$queryString);
 
         return $result['body']['Contacts'];
     }
 
     public function find(string $contactId): array
     {
-        $result = parent::get('contacts/'.$contactId);
+        $result = parent::get('Contacts/'.$contactId);
 
         return $result['body']['Contacts'][0];
     }
 
     public function update(string $contactId, array $data): array
     {
-        $result = $this->post('contacts/'.$contactId, $data);
+        $result = $this->post('Contacts/'.$contactId, $data);
 
         return $result['body']['Contacts'][0];
     }
 
     public function store(array $data): array
     {
-        $result = $this->post('contacts', $data);
+        $result = $this->post('Contacts', $data);
 
         return $result['body']['Contacts'][0];
     }

--- a/src/Resources/Invoices.php
+++ b/src/Resources/Invoices.php
@@ -2,53 +2,65 @@
 
 namespace Dcblogdev\Xero\Resources;
 
+use Dcblogdev\Xero\Enums\FilterOptions;
 use Dcblogdev\Xero\Xero;
+use InvalidArgumentException;
 
 class Invoices extends Xero
 {
-    public function get(int $page = 1, string $where = ''): array
-    {
-        $params = http_build_query([
-            'page' => $page,
-            'where' => $where
-        ]);
+    protected array $queryString = [];
 
-        $result = parent::get('invoices?'.$params);
+    public function filter($key, $value): static
+    {
+        if (! FilterOptions::isValid($key)) {
+            throw new InvalidArgumentException("Filter option '$key' is not valid.");
+        }
+
+        $this->queryString[$key] = $value;
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        $queryString = $this->formatQueryStrings($this->queryString);
+
+        $result = parent::get('Invoices?'.$queryString);
 
         return $result['body']['Invoices'];
     }
 
-    public function find(string $contactId): array
+    public function find(string $invoiceId): array
     {
-        $result = parent::get('invoices/'.$contactId);
+        $result = parent::get('Invoices/'.$invoiceId);
 
         return $result['body']['Invoices'][0];
     }
 
     public function onlineUrl(string $invoiceId): string
     {
-        $result = parent::get('invoices/'.$invoiceId.'/OnlineInvoice');
+        $result = parent::get('Invoices/'.$invoiceId.'/OnlineInvoice');
 
         return $result['body']['OnlineInvoices'][0]['OnlineInvoiceUrl'];
     }
 
     public function update(string $invoiceId, array $data): array
     {
-        $result = parent::post('invoices/'.$invoiceId, $data);
+        $result = parent::post('Invoices/'.$invoiceId, $data);
 
         return $result['body']['Invoices'][0];
     }
 
     public function store(array $data): array
     {
-        $result = parent::post('invoices', $data);
+        $result = parent::post('Invoices', $data);
 
         return $result['body']['Invoices'][0];
     }
     
     public function attachments(string $invoiceId): array
     {
-        $result = parent::get('invoices/'.$invoiceId.'/Attachments');
+        $result = parent::get('Invoices/'.$invoiceId.'/Attachments');
 
         return $result['body']['Attachments'];
     }
@@ -58,7 +70,7 @@ class Invoices extends Xero
         // Depending on the application we may want to get it by the FileName instead fo the AttachmentId
         $nameOrId = $attachmentId ? $attachmentId : $fileName;
         
-        $result = parent::get('invoices/'.$invoiceId.'/Attachments/'.$nameOrId);
+        $result = parent::get('Invoices/'.$invoiceId.'/Attachments/'.$nameOrId);
 
         return $result['body'];
     }

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -293,8 +293,16 @@ class Xero
      * @return array
      * @throws Exception
      */
-    protected function guzzle(string $type, string $request, array $data = [], bool $raw = false, $accept = 'application/json', $headers = []): array
+    protected function guzzle(string $type, string $request, array $data = [], bool $raw = false, string $accept = 'application/json', array $headers = []): array
     {
+        if ($data === []) {
+            $data = null;
+        }
+
+        //contacts?where=ContactID==Guid("74ea95ea-6e1e-435d-9c30-0dff8ae1bd80
+
+        //dd([$request]);
+
         try {
             $response = Http::withToken($this->getAccessToken())
                 ->withHeaders(array_merge(['Xero-tenant-id' => $this->getTenantId()], $headers))
@@ -308,7 +316,7 @@ class Xero
             ];
         } catch (RequestException $e) {
             $response = json_decode($e->response->body());
-            throw new Exception($response->Detail);
+            throw new Exception($response->Detail ?? "Type: {$response->Type} Message: {$response->Message} Error Number: {$response->ErrorNumber}");
         } catch (Exception $e) {
             throw new Exception($e->getMessage());
         }
@@ -337,5 +345,16 @@ class Xero
         } catch (Exception $e) {
             throw new Exception($e->getMessage());
         }
+    }
+
+    public function formatQueryStrings(array $params): string
+    {
+        $queryString = '';
+
+        foreach ($params as $key => $value) {
+            $queryString .= "$key=$value&";
+        }
+
+        return rtrim($queryString, '&');
     }
 }

--- a/tests/Enums/FilterOptionsTest.php
+++ b/tests/Enums/FilterOptionsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Dcblogdev\Xero\Enums\FilterOptions;
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+test('a valid option returns true', function(){
+    assertTrue(FilterOptions::isValid('ids'));
+    assertTrue(FilterOptions::isValid('includeArchived'));
+    assertTrue(FilterOptions::isValid('order'));
+    assertTrue(FilterOptions::isValid('page'));
+    assertTrue(FilterOptions::isValid('searchTerm'));
+    assertTrue(FilterOptions::isValid('summaryOnly'));
+    assertTrue(FilterOptions::isValid('where'));
+});
+
+test('an invalid option returns false', function(){
+    assertFalse(FilterOptions::isValid('bogus'));
+});

--- a/tests/Resources/ContactsTest.php
+++ b/tests/Resources/ContactsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Resources\Contacts;
+
+test('invalid filter option throws exception', function(){
+   Xero::contacts()
+       ->filter('bogus', 1)
+       ->get();
+})->throws(InvalidArgumentException::class, "Filter option 'bogus' is not valid.");
+
+test('filter returns object', function(){
+
+    $filter = (new Contacts())->filter('ids', '1234');
+
+    expect($filter)->toBeObject();
+});

--- a/tests/Resources/InvoicesTest.php
+++ b/tests/Resources/InvoicesTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Resources\Invoices;
+
+test('invalid filter option throws exception', function(){
+   Xero::invoices()
+       ->filter('bogus', 1)
+       ->get();
+})->throws(InvalidArgumentException::class, "Filter option 'bogus' is not valid.");
+
+test('filter returns object', function(){
+
+    $filter = (new Invoices())->filter('ids', '1234');
+
+    expect($filter)->toBeObject();
+});


### PR DESCRIPTION
This PR changes filtering from:

```php
Xero::contacts()->get(int $page = 1, string $where = null)
```

to fluent methods:

->filter() methods are optional and can add multiple filters. Only filters set out in an emum are supported:

```php
 case IDS = 'ids';
 case INCLUDEARCHIVED = 'includeArchived';
 case ORDER = 'order';
 case PAGE = 'page';
 case SEARCHTERM = 'searchTerm';
 case SUMMARYONLY = 'summaryOnly';
 case WHERE = 'where';
```

## Usage

```php
Xero::contacts()
->filter('page', 1)
->filter('where', 'EmailAddress=="info@abfl.com"')
->filter('where', 'ContactID==Guid("74ea95ea-6e1e-435d-9c30-0dff8ae1bd80")')
->filter('searchTerm', 'info')
->filter('includeArchived', 'false')
->filter('order', 'name')
->filter('summaryOnly', 'true')
->get();
```