### PR TITLE
TypeError on Keep Alive artisan command

### DIFF
--- a/src/Models/XeroToken.php
+++ b/src/Models/XeroToken.php
@@ -31,4 +31,8 @@ class XeroToken extends Model
             fn(): DateTimeInterface => $this->updated_at->addSeconds($this->expires_in)
         );
     }
+
+    protected $casts = [
+        'expires_in' => 'integer',
+    ];
 }


### PR DESCRIPTION
Added Eloquent attribute casting in the model to address the TypeError on the php artisan xero:keep-alive command. I have proposed this solution over a migration on the xero-tokens database to minimise the impact of the fix.