### PR TITLE
Add formatDate method to handle date parsing and formatting

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -361,7 +361,7 @@ class Xero
      * @throws DateInvalidTimeZoneException if the input isn’t valid
      * @throws \DateMalformedStringException
      */
-    public function formatDate(string $date, string $format = 'Y-m-d H:i:s'): string
+    public static function formatDate(string $date, string $format = 'Y-m-d H:i:s'): string
     {
         if (preg_match('#/Date\((\d+)([+-]\d{4})\)/#', $date, $m)) {
             $timestamp = (int) $m[1] / 1000;

--- a/tests/XeroTest.php
+++ b/tests/XeroTest.php
@@ -149,3 +149,31 @@ test('can get tokens when encrypted', function () {
 
     expect($data)->toBe('1234');
 });
+
+test('formats Microsoft JSON date with timezone offset', function () {
+    $input = '/Date(1663257600000+0100)/'; // 2022-09-15 01:00:00 +01:00
+    $formatted = Xero::formatDate($input);
+
+    expect($formatted)->toBe('2022-09-15 01:00:00');
+});
+
+test('formats standard ISO 8601 date string', function () {
+    $input = '2023-05-19T14:00:00+00:00';
+    $formatted = Xero::formatDate($input);
+
+    expect($formatted)->toBe('2023-05-19 14:00:00');
+});
+
+test('returns empty string for invalid date input', function () {
+    $input = 'invalid-date-format';
+    $formatted = Xero::formatDate($input);
+
+    expect($formatted)->toBe('');
+});
+
+test('formats Microsoft JSON date with UTC offset', function () {
+    $input = '/Date(1663257600000+0000)/'; // 2022-09-15 00:00:00 UTC
+    $formatted = Xero::formatDate($input);
+
+    expect($formatted)->toBe('2022-09-15 00:00:00');
+});

--- a/tests/XeroTest.php
+++ b/tests/XeroTest.php
@@ -151,10 +151,10 @@ test('can get tokens when encrypted', function () {
 });
 
 test('formats Microsoft JSON date with timezone offset', function () {
-    $input = '/Date(1663257600000+0100)/'; // 2022-09-15 01:00:00 +01:00
+    $input = '/Date(1663257600000+0100)/';
     $formatted = Xero::formatDate($input);
 
-    expect($formatted)->toBe('2022-09-15 01:00:00');
+    expect($formatted)->toBe('2022-09-15 17:00:00');
 });
 
 test('formats standard ISO 8601 date string', function () {
@@ -172,8 +172,8 @@ test('returns empty string for invalid date input', function () {
 });
 
 test('formats Microsoft JSON date with UTC offset', function () {
-    $input = '/Date(1663257600000+0000)/'; // 2022-09-15 00:00:00 UTC
+    $input = '/Date(1663257600000+0000)/';
     $formatted = Xero::formatDate($input);
 
-    expect($formatted)->toBe('2022-09-15 00:00:00');
+    expect($formatted)->toBe('2022-09-15 16:00:00');
 });


### PR DESCRIPTION
This pull request introduces a new `formatDate` method in the `Xero` class to handle date parsing and formatting, along with corresponding unit tests to ensure its functionality. It also includes updates to the imports for better exception handling.

### New functionality:

* **Added `formatDate` method**: Introduced a method in `src/Xero.php` to parse and format date strings, supporting Microsoft JSON dates and ISO 8601 formats. The method throws exceptions for invalid inputs and handles timezone offsets.

### Testing enhancements:

* **Unit tests for `formatDate`**: Added tests in `tests/XeroTest.php` to validate the `formatDate` method's behavior with various input formats, including Microsoft JSON dates, ISO 8601 strings, and invalid inputs.

### Codebase improvements:

* **Updated imports**: Added `DateInvalidTimeZoneException`, `DateTime`, `DateTimeZone`, and `InvalidArgumentException` to `src/Xero.php` for enhanced exception handling and functionality.