### PR TITLE
Update PHP versions in GitHub Actions to include 8.3 and 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3', '8.4']
 
     name: PHP ${{ matrix.php-versions }}
 


### PR DESCRIPTION
This pull request updates the PHP versions tested in the GitHub Actions workflow to include newer versions.

Updated the `php-versions` matrix to include PHP 8.3 and 8.4, replacing the previous version 8.2.