### PR TITLE
Use http_build_query for query string formatting in formatQueryString…

### DIFF
--- a/src/Actions/formatQueryStringsAction.php
+++ b/src/Actions/formatQueryStringsAction.php
@@ -8,12 +8,6 @@ class formatQueryStringsAction
 {
     public function __invoke(array $params): string
     {
-        $queryString = '';
-
-        foreach ($params as $key => $value) {
-            $queryString .= "$key=$value&";
-        }
-
-        return mb_rtrim($queryString, '&');
+        return http_build_query($params, '', '&', PHP_QUERY_RFC3986);
     }
 }


### PR DESCRIPTION
This pull request simplifies the `formatQueryStringsAction` class by replacing a custom query string construction loop with the built-in `http_build_query` function.

Code simplification:

* [`src/Actions/formatQueryStringsAction.php`]: Replaced the manual loop for building query strings with the `http_build_query` function to improve readability and compliance with RFC 3986.