### PR TITLE
Refactor StoreTokenAction to merge tenant data conditionally

### DIFF
--- a/src/Actions/StoreTokenAction.php
+++ b/src/Actions/StoreTokenAction.php
@@ -21,6 +21,9 @@ class StoreTokenAction
         ];
 
         if ($tenantId) {
+            if ($tenantData !== []) {
+                $data = array_merge($data, $tenantData);
+            }
             $where = ['tenant_id' => $tenantId];
         } elseif ($tenantData !== []) {
             $data = array_merge($data, $tenantData);

--- a/tests/Actions/StoreTokenActionTest.php
+++ b/tests/Actions/StoreTokenActionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\Actions\StoreTokenAction;
+use Dcblogdev\Xero\Models\XeroToken;
+
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Laravel\assertDatabaseHas;
+
+test('store token action creates a new token without tenant data', function () {
+    $token = [
+        'id_token' => 'test_id_token',
+        'access_token' => 'test_access_token',
+        'expires_in' => 3600,
+        'token_type' => 'Bearer',
+        'refresh_token' => 'test_refresh_token',
+        'scope' => 'test_scope',
+    ];
+
+    $result = app(StoreTokenAction::class)($token);
+
+    expect($result)->toBeInstanceOf(XeroToken::class);
+    assertDatabaseCount(XeroToken::class, 1);
+    assertDatabaseHas('xero_tokens', [
+        'id' => 1,
+        'access_token' => config('xero.encrypt') ? null : 'test_access_token',
+        'refresh_token' => config('xero.encrypt') ? null : 'test_refresh_token',
+        'scopes' => 'test_scope',
+    ]);
+});
+
+test('store token action creates a new token with tenant data', function () {
+    $token = [
+        'id_token' => 'test_id_token',
+        'access_token' => 'test_access_token',
+        'expires_in' => 3600,
+        'token_type' => 'Bearer',
+        'refresh_token' => 'test_refresh_token',
+        'scope' => 'test_scope',
+    ];
+
+    $tenantData = [
+        'tenant_id' => 'test_tenant_id',
+        'tenant_name' => 'Test Tenant',
+    ];
+
+    $result = app(StoreTokenAction::class)($token, $tenantData);
+
+    expect($result)->toBeInstanceOf(XeroToken::class);
+    assertDatabaseCount(XeroToken::class, 1);
+    assertDatabaseHas('xero_tokens', [
+        'tenant_id' => 'test_tenant_id',
+        'tenant_name' => 'Test Tenant',
+        'access_token' => config('xero.encrypt') ? null : 'test_access_token',
+        'refresh_token' => config('xero.encrypt') ? null : 'test_refresh_token',
+        'scopes' => 'test_scope',
+    ]);
+});
+
+test('store token action updates an existing token with tenant id and tenant data', function () {
+    // First, create a token
+    $token = XeroToken::factory()->create([
+        'tenant_id' => 'test_tenant_id',
+        'tenant_name' => 'Old Tenant Name',
+    ]);
+
+    // Then update it with new data
+    $newToken = [
+        'id_token' => 'new_id_token',
+        'access_token' => 'new_access_token',
+        'expires_in' => 7200,
+        'token_type' => 'Bearer',
+        'refresh_token' => 'new_refresh_token',
+        'scope' => 'new_scope',
+    ];
+
+    $tenantData = [
+        'tenant_name' => 'New Tenant Name',
+    ];
+
+    $result = app(StoreTokenAction::class)($newToken, $tenantData, 'test_tenant_id');
+
+    expect($result)->toBeInstanceOf(XeroToken::class);
+    assertDatabaseCount(XeroToken::class, 1);
+    assertDatabaseHas('xero_tokens', [
+        'tenant_id' => 'test_tenant_id',
+        'tenant_name' => 'New Tenant Name',
+        'access_token' => config('xero.encrypt') ? null : 'new_access_token',
+        'refresh_token' => config('xero.encrypt') ? null : 'new_refresh_token',
+        'scopes' => 'new_scope',
+    ]);
+});


### PR DESCRIPTION
This pull request enhances the `StoreTokenAction` functionality by improving how tenant data is handled and introduces comprehensive test coverage for various token storage scenarios. The changes ensure better flexibility and robustness when storing or updating tokens with or without tenant data.

### Enhancements to `StoreTokenAction`:

* Updated the `__invoke` method in `src/Actions/StoreTokenAction.php` to handle scenarios where tenant data is provided alongside a tenant ID, ensuring that tenant data is merged into the token data only when necessary.

### Test Coverage:

* Added new tests in `tests/Actions/StoreTokenActionTest.php` to verify:
  - Storing a token without tenant data.
  - Storing a token with tenant data.
  - Updating an existing token with a tenant ID and new tenant data.