### PR TITLE
Add DTOs and enums for Contact and Invoice management

### DIFF
--- a/src/DTOs/ContactDTO.php
+++ b/src/DTOs/ContactDTO.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\DTOs;
+
+use Dcblogdev\Xero\Enums\ContactStatus;
+
+class ContactDTO
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $firstName = null,
+        public ?string $lastName = null,
+        public ?string $emailAddress = null,
+        public ?string $accountNumber = null,
+        public ?string $bankAccountDetails = null,
+        public ?string $taxNumber = null,
+        public ?string $accountsReceivableTaxType = null,
+        public ?string $accountsPayableTaxType = null,
+        public ?string $contactStatus = ContactStatus::Active->value,
+        public ?bool $isSupplier = false,
+        public ?bool $isCustomer = false,
+        public ?string $defaultCurrency = null,
+        public ?string $website = null,
+        public ?string $purchasesDefaultAccountCode = null,
+        public ?string $salesDefaultAccountCode = null,
+        /** @var array<int, array<string, mixed>> */
+        public ?array $addresses = [],
+        /** @var array<int, array<string, mixed>> */
+        public ?array $phones = [],
+        /** @var array<int, array<string, mixed>> */
+        public ?array $contactPersons = [],
+        public ?bool $hasAttachments = false,
+        public ?bool $hasValidationErrors = false,
+    ) {}
+
+    /**
+     * Create an address array for the contact
+     *
+     * @return array<string, string|null>
+     */
+    public static function createAddress(
+        string $addressType,
+        ?string $addressLine1 = null,
+        ?string $addressLine2 = null,
+        ?string $addressLine3 = null,
+        ?string $addressLine4 = null,
+        ?string $city = null,
+        ?string $region = null,
+        ?string $postalCode = null,
+        ?string $country = null,
+        ?string $attentionTo = null
+    ): array {
+        return [
+            'AddressType' => $addressType,
+            'AddressLine1' => $addressLine1,
+            'AddressLine2' => $addressLine2,
+            'AddressLine3' => $addressLine3,
+            'AddressLine4' => $addressLine4,
+            'City' => $city,
+            'Region' => $region,
+            'PostalCode' => $postalCode,
+            'Country' => $country,
+            'AttentionTo' => $attentionTo,
+        ];
+    }
+
+    /**
+     * Create a phone array for the contact
+     *
+     * @return array<string, string|null>
+     */
+    public static function createPhone(
+        string $phoneType,
+        ?string $phoneNumber = null,
+        ?string $phoneAreaCode = null,
+        ?string $phoneCountryCode = null
+    ): array {
+        return [
+            'PhoneType' => $phoneType,
+            'PhoneNumber' => $phoneNumber,
+            'PhoneAreaCode' => $phoneAreaCode,
+            'PhoneCountryCode' => $phoneCountryCode,
+        ];
+    }
+
+    /**
+     * Create a contact person array for the contact
+     *
+     * @return array<string, string|bool|null>
+     */
+    public static function createContactPerson(
+        ?string $firstName = null,
+        ?string $lastName = null,
+        ?string $emailAddress = null,
+        ?bool $includeInEmails = false
+    ): array {
+        return [
+            'FirstName' => $firstName,
+            'LastName' => $lastName,
+            'EmailAddress' => $emailAddress,
+            'IncludeInEmails' => $includeInEmails,
+        ];
+    }
+
+    /**
+     * Convert the DTO to an array for the Xero API
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'Name' => $this->name,
+            'FirstName' => $this->firstName,
+            'LastName' => $this->lastName,
+            'EmailAddress' => $this->emailAddress,
+            'AccountNumber' => $this->accountNumber,
+            'BankAccountDetails' => $this->bankAccountDetails,
+            'TaxNumber' => $this->taxNumber,
+            'AccountsReceivableTaxType' => $this->accountsReceivableTaxType,
+            'AccountsPayableTaxType' => $this->accountsPayableTaxType,
+            'ContactStatus' => $this->contactStatus,
+            'IsSupplier' => $this->isSupplier,
+            'IsCustomer' => $this->isCustomer,
+            'DefaultCurrency' => $this->defaultCurrency,
+            'Website' => $this->website,
+            'PurchasesDefaultAccountCode' => $this->purchasesDefaultAccountCode,
+            'SalesDefaultAccountCode' => $this->salesDefaultAccountCode,
+            'Addresses' => $this->addresses,
+            'Phones' => $this->phones,
+            'ContactPersons' => $this->contactPersons,
+            'HasAttachments' => $this->hasAttachments,
+            'HasValidationErrors' => $this->hasValidationErrors,
+        ], function (mixed $value) {
+            return $value !== null;
+        });
+    }
+}

--- a/src/DTOs/InvoiceDTO.php
+++ b/src/DTOs/InvoiceDTO.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\DTOs;
+
+use Dcblogdev\Xero\Enums\InvoiceLineAmountType;
+use Dcblogdev\Xero\Enums\InvoiceStatus;
+use Dcblogdev\Xero\Enums\InvoiceType;
+
+class InvoiceDTO
+{
+    public function __construct(
+        public ?string $invoiceID = null,
+        public ?string $type = InvoiceType::AccRec->value, // ACCREC for sales invoices, ACCPAY for bills
+        public ?string $invoiceNumber = null,
+        public ?string $reference = null,
+        public ?string $date = null,
+        public ?string $dueDate = null,
+        public ?string $status = InvoiceStatus::Draft->value,
+        public ?string $lineAmountTypes = InvoiceLineAmountType::Exclusive->value,
+        public ?string $currencyCode = null,
+        public ?string $currencyRate = null,
+        public ?string $subTotal = null,
+        public ?string $totalTax = null,
+        public ?string $total = null,
+        public ?string $contactID = null,
+        /** @var array<int, array<string, mixed>> */
+        public ?array $contact = null,
+        /** @var array<int, array<string, mixed>> */
+        public ?array $lineItems = [],
+        /** @var array<int, array<string, mixed>> */
+        public ?array $payments = [],
+        /** @var array<int, array<string, mixed>> */
+        public ?array $creditNotes = [],
+        /** @var array<int, array<string, mixed>> */
+        public ?array $prepayments = [],
+        /** @var array<int, array<string, mixed>> */
+        public ?array $overpayments = [],
+        public ?bool $hasAttachments = false,
+        public ?bool $isDiscounted = false,
+        public ?bool $hasErrors = false,
+    ) {}
+
+    /**
+     * Create a line item array for the invoice
+     *
+     * @param  array<int, array<string, mixed>>|null  $tracking
+     * @return array<string, mixed>
+     */
+    public static function createLineItem(
+        ?string $description = null,
+        string|int|null $quantity = null,
+        string|float|null $unitAmount = null,
+        ?int $accountCode = null,
+        ?string $itemCode = null,
+        ?string $taxType = null,
+        ?string $taxAmount = null,
+        ?string $lineAmount = null,
+        ?string $discountRate = null,
+        ?array $tracking = null,
+    ): array {
+        return array_filter([
+            'Description' => $description,
+            'Quantity' => $quantity,
+            'UnitAmount' => $unitAmount,
+            'AccountCode' => $accountCode,
+            'ItemCode' => $itemCode,
+            'TaxType' => $taxType,
+            'TaxAmount' => $taxAmount,
+            'LineAmount' => $lineAmount,
+            'DiscountRate' => $discountRate,
+            'Tracking' => $tracking,
+        ], function (mixed $value) {
+            return $value !== null;
+        });
+    }
+
+    /**
+     * Convert the DTO to an array for the Xero API
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'InvoiceID' => $this->invoiceID,
+            'Type' => $this->type,
+            'InvoiceNumber' => $this->invoiceNumber,
+            'Reference' => $this->reference,
+            'Date' => $this->date,
+            'DueDate' => $this->dueDate,
+            'Status' => $this->status,
+            'LineAmountTypes' => $this->lineAmountTypes,
+            'CurrencyCode' => $this->currencyCode,
+            'CurrencyRate' => $this->currencyRate,
+            'SubTotal' => $this->subTotal,
+            'TotalTax' => $this->totalTax,
+            'Total' => $this->total,
+            'Contact' => $this->contactID ? ['ContactID' => $this->contactID] : $this->contact,
+            'LineItems' => $this->lineItems,
+            'HasAttachments' => $this->hasAttachments,
+            'IsDiscounted' => $this->isDiscounted,
+        ], fn (mixed $value) => $value !== null && $value !== []);
+    }
+}

--- a/src/Enums/ContactStatus.php
+++ b/src/Enums/ContactStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\Enums;
+
+enum ContactStatus: string
+{
+    case Active = 'ACTIVE';
+    case Archived = 'ARCHIVED';
+    case GDPRRequest = 'GDPRREQUEST';
+
+    public static function isValid(string $value): bool
+    {
+        $validValues = array_map(fn (mixed $case) => $case->value, self::cases());
+
+        return in_array($value, $validValues);
+    }
+}

--- a/src/Enums/FilterOptions.php
+++ b/src/Enums/FilterOptions.php
@@ -6,14 +6,14 @@ namespace Dcblogdev\Xero\Enums;
 
 enum FilterOptions: string
 {
-    case IDS = 'ids';
-    case INCLUDEARCHIVED = 'includeArchived';
-    case ORDER = 'order';
-    case PAGE = 'page';
-    case SEARCHTERM = 'searchTerm';
-    case SUMMARYONLY = 'summaryOnly';
-    case WHERE = 'where';
-    case STATUSES = 'Statuses';
+    case Ids = 'ids';
+    case IncludeArchived = 'includeArchived';
+    case Order = 'order';
+    case Page = 'page';
+    case SearchTerm = 'searchTerm';
+    case SummaryOnly = 'summaryOnly';
+    case Where = 'where';
+    case Statuses = 'Statuses';
 
     public static function isValid(string $value): bool
     {

--- a/src/Enums/InvoiceLineAmountType.php
+++ b/src/Enums/InvoiceLineAmountType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\Enums;
+
+enum InvoiceLineAmountType: string
+{
+    case Exclusive = 'Exclusive';
+    case Inclusive = 'Inclusive';
+    case NoTax = 'NoTax';
+
+    public static function isValid(string $value): bool
+    {
+        $validValues = array_map(fn (mixed $case) => $case->value, self::cases());
+
+        return in_array($value, $validValues);
+    }
+}

--- a/src/Enums/InvoiceStatus.php
+++ b/src/Enums/InvoiceStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\Enums;
+
+enum InvoiceStatus: string
+{
+    case Authorised = 'AUTHORISED';
+    case Deleted = 'DELETED';
+    case Draft = 'DRAFT';
+    case Paid = 'PAID';
+    case Submitted = 'SUBMITTED';
+    case Voided = 'VOIDED';
+
+    public static function isValid(string $value): bool
+    {
+        $validValues = array_map(fn (mixed $case) => $case->value, self::cases());
+
+        return in_array($value, $validValues);
+    }
+}

--- a/src/Enums/InvoiceType.php
+++ b/src/Enums/InvoiceType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\Enums;
+
+enum InvoiceType: string
+{
+    case AccPay = 'ACCPAY';
+    case AccRec = 'ACCREC';
+
+    public static function isValid(string $value): bool
+    {
+        $validValues = array_map(fn (mixed $case) => $case->value, self::cases());
+
+        return in_array($value, $validValues);
+    }
+}

--- a/tests/DTOs/ContactDTOTest.php
+++ b/tests/DTOs/ContactDTOTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\DTOs\ContactDTO;
+use Dcblogdev\Xero\Enums\ContactStatus;
+
+test('contact dto can be instantiated with default values', function () {
+    $contactDTO = new ContactDTO();
+
+    expect($contactDTO)->toBeInstanceOf(ContactDTO::class)
+        ->and($contactDTO->name)->toBeNull()
+        ->and($contactDTO->firstName)->toBeNull()
+        ->and($contactDTO->lastName)->toBeNull()
+        ->and($contactDTO->emailAddress)->toBeNull()
+        ->and($contactDTO->accountNumber)->toBeNull()
+        ->and($contactDTO->bankAccountDetails)->toBeNull()
+        ->and($contactDTO->taxNumber)->toBeNull()
+        ->and($contactDTO->accountsReceivableTaxType)->toBeNull()
+        ->and($contactDTO->accountsPayableTaxType)->toBeNull()
+        ->and($contactDTO->contactStatus)->toBe(ContactStatus::Active->value)
+        ->and($contactDTO->isSupplier)->toBeFalse()
+        ->and($contactDTO->isCustomer)->toBeFalse()
+        ->and($contactDTO->defaultCurrency)->toBeNull()
+        ->and($contactDTO->website)->toBeNull()
+        ->and($contactDTO->purchasesDefaultAccountCode)->toBeNull()
+        ->and($contactDTO->salesDefaultAccountCode)->toBeNull()
+        ->and($contactDTO->addresses)->toBe([])
+        ->and($contactDTO->phones)->toBe([])
+        ->and($contactDTO->contactPersons)->toBe([])
+        ->and($contactDTO->hasAttachments)->toBeFalse()
+        ->and($contactDTO->hasValidationErrors)->toBeFalse();
+});
+
+test('contact dto can be instantiated with custom values', function () {
+    $contactDTO = new ContactDTO(
+        name: 'Test Company',
+        firstName: 'John',
+        lastName: 'Doe',
+        emailAddress: 'john.doe@example.com',
+        accountNumber: 'ACC123',
+        bankAccountDetails: '123456789',
+        taxNumber: 'TAX123',
+        accountsReceivableTaxType: 'OUTPUT',
+        accountsPayableTaxType: 'INPUT',
+        contactStatus: ContactStatus::Archived->value,
+        isSupplier: true,
+        isCustomer: true,
+        defaultCurrency: 'USD',
+        website: 'https://example.com',
+        purchasesDefaultAccountCode: 'P123',
+        salesDefaultAccountCode: 'S123',
+        addresses: [['AddressType' => 'POBOX']],
+        phones: [['PhoneType' => 'MOBILE']],
+        contactPersons: [['FirstName' => 'Jane']],
+        hasAttachments: true,
+        hasValidationErrors: true
+    );
+
+    expect($contactDTO)->toBeInstanceOf(ContactDTO::class)
+        ->and($contactDTO->name)->toBe('Test Company')
+        ->and($contactDTO->firstName)->toBe('John')
+        ->and($contactDTO->lastName)->toBe('Doe')
+        ->and($contactDTO->emailAddress)->toBe('john.doe@example.com')
+        ->and($contactDTO->accountNumber)->toBe('ACC123')
+        ->and($contactDTO->bankAccountDetails)->toBe('123456789')
+        ->and($contactDTO->taxNumber)->toBe('TAX123')
+        ->and($contactDTO->accountsReceivableTaxType)->toBe('OUTPUT')
+        ->and($contactDTO->accountsPayableTaxType)->toBe('INPUT')
+        ->and($contactDTO->contactStatus)->toBe(ContactStatus::Archived->value)
+        ->and($contactDTO->isSupplier)->toBeTrue()
+        ->and($contactDTO->isCustomer)->toBeTrue()
+        ->and($contactDTO->defaultCurrency)->toBe('USD')
+        ->and($contactDTO->website)->toBe('https://example.com')
+        ->and($contactDTO->purchasesDefaultAccountCode)->toBe('P123')
+        ->and($contactDTO->salesDefaultAccountCode)->toBe('S123')
+        ->and($contactDTO->addresses)->toBe([['AddressType' => 'POBOX']])
+        ->and($contactDTO->phones)->toBe([['PhoneType' => 'MOBILE']])
+        ->and($contactDTO->contactPersons)->toBe([['FirstName' => 'Jane']])
+        ->and($contactDTO->hasAttachments)->toBeTrue()
+        ->and($contactDTO->hasValidationErrors)->toBeTrue();
+});
+
+test('createAddress static method returns correct array', function () {
+    $address = ContactDTO::createAddress(
+        addressType: 'POBOX',
+        addressLine1: '123 Main St',
+        addressLine2: 'Suite 100',
+        addressLine3: 'Building A',
+        addressLine4: 'Floor 2',
+        city: 'Anytown',
+        region: 'State',
+        postalCode: '12345',
+        country: 'USA',
+        attentionTo: 'John Doe'
+    );
+
+    expect($address)->toBe([
+        'AddressType' => 'POBOX',
+        'AddressLine1' => '123 Main St',
+        'AddressLine2' => 'Suite 100',
+        'AddressLine3' => 'Building A',
+        'AddressLine4' => 'Floor 2',
+        'City' => 'Anytown',
+        'Region' => 'State',
+        'PostalCode' => '12345',
+        'Country' => 'USA',
+        'AttentionTo' => 'John Doe',
+    ]);
+});
+
+test('createPhone static method returns correct array', function () {
+    $phone = ContactDTO::createPhone(
+        phoneType: 'MOBILE',
+        phoneNumber: '555-1234',
+        phoneAreaCode: '123',
+        phoneCountryCode: '1'
+    );
+
+    expect($phone)->toBe([
+        'PhoneType' => 'MOBILE',
+        'PhoneNumber' => '555-1234',
+        'PhoneAreaCode' => '123',
+        'PhoneCountryCode' => '1',
+    ]);
+});
+
+test('createContactPerson static method returns correct array', function () {
+    $contactPerson = ContactDTO::createContactPerson(
+        firstName: 'Jane',
+        lastName: 'Smith',
+        emailAddress: 'jane.smith@example.com',
+        includeInEmails: true
+    );
+
+    expect($contactPerson)->toBe([
+        'FirstName' => 'Jane',
+        'LastName' => 'Smith',
+        'EmailAddress' => 'jane.smith@example.com',
+        'IncludeInEmails' => true,
+    ]);
+});
+
+test('toArray method returns correct array structure', function () {
+    $contactDTO = new ContactDTO(
+        name: 'Test Company',
+        firstName: 'John',
+        lastName: 'Doe',
+        emailAddress: 'john.doe@example.com',
+        isSupplier: true,
+        addresses: [
+            ContactDTO::createAddress('POBOX', '123 Main St'),
+        ],
+        phones: [
+            ContactDTO::createPhone('MOBILE', '555-1234'),
+        ],
+        contactPersons: [
+            ContactDTO::createContactPerson('Jane', 'Smith'),
+        ]
+    );
+
+    $array = $contactDTO->toArray();
+
+    expect($array)->toBeArray()
+        ->and($array)->toHaveKey('Name', 'Test Company')
+        ->and($array)->toHaveKey('FirstName', 'John')
+        ->and($array)->toHaveKey('LastName', 'Doe')
+        ->and($array)->toHaveKey('EmailAddress', 'john.doe@example.com')
+        ->and($array)->toHaveKey('ContactStatus', ContactStatus::Active->value)
+        ->and($array)->toHaveKey('IsSupplier', true)
+        ->and($array)->toHaveKey('IsCustomer', false)
+        ->and($array)->toHaveKey('Addresses')
+        ->and($array['Addresses'][0])->toHaveKey('AddressType', 'POBOX')
+        ->and($array['Addresses'][0])->toHaveKey('AddressLine1', '123 Main St')
+        ->and($array)->toHaveKey('Phones')
+        ->and($array['Phones'][0])->toHaveKey('PhoneType', 'MOBILE')
+        ->and($array['Phones'][0])->toHaveKey('PhoneNumber', '555-1234')
+        ->and($array)->toHaveKey('ContactPersons')
+        ->and($array['ContactPersons'][0])->toHaveKey('FirstName', 'Jane')
+        ->and($array['ContactPersons'][0])->toHaveKey('LastName', 'Smith');
+});
+
+test('toArray method filters out null values', function () {
+    $contactDTO = new ContactDTO(
+        name: 'Test Company',
+        emailAddress: null,
+        website: null
+    );
+
+    $array = $contactDTO->toArray();
+
+    expect($array)->toHaveKey('Name')
+        ->and($array)->not->toHaveKey('EmailAddress')
+        ->and($array)->not->toHaveKey('Website');
+});

--- a/tests/DTOs/InvoiceDTOTest.php
+++ b/tests/DTOs/InvoiceDTOTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\DTOs\InvoiceDTO;
+use Dcblogdev\Xero\Enums\InvoiceLineAmountType;
+use Dcblogdev\Xero\Enums\InvoiceStatus;
+use Dcblogdev\Xero\Enums\InvoiceType;
+
+test('invoice dto can be instantiated with default values', function () {
+    $invoiceDTO = new InvoiceDTO();
+
+    expect($invoiceDTO)->toBeInstanceOf(InvoiceDTO::class)
+        ->and($invoiceDTO->invoiceID)->toBeNull()
+        ->and($invoiceDTO->type)->toBe(InvoiceType::AccRec->value)
+        ->and($invoiceDTO->invoiceNumber)->toBeNull()
+        ->and($invoiceDTO->reference)->toBeNull()
+        ->and($invoiceDTO->date)->toBeNull()
+        ->and($invoiceDTO->dueDate)->toBeNull()
+        ->and($invoiceDTO->status)->toBe(InvoiceStatus::Draft->value)
+        ->and($invoiceDTO->lineAmountTypes)->toBe(InvoiceLineAmountType::Exclusive->value)
+        ->and($invoiceDTO->currencyCode)->toBeNull()
+        ->and($invoiceDTO->currencyRate)->toBeNull()
+        ->and($invoiceDTO->subTotal)->toBeNull()
+        ->and($invoiceDTO->totalTax)->toBeNull()
+        ->and($invoiceDTO->total)->toBeNull()
+        ->and($invoiceDTO->contactID)->toBeNull()
+        ->and($invoiceDTO->contact)->toBeNull()
+        ->and($invoiceDTO->lineItems)->toBe([])
+        ->and($invoiceDTO->payments)->toBe([])
+        ->and($invoiceDTO->creditNotes)->toBe([])
+        ->and($invoiceDTO->prepayments)->toBe([])
+        ->and($invoiceDTO->overpayments)->toBe([])
+        ->and($invoiceDTO->hasAttachments)->toBeFalse()
+        ->and($invoiceDTO->isDiscounted)->toBeFalse()
+        ->and($invoiceDTO->hasErrors)->toBeFalse();
+});
+
+test('invoice dto can be instantiated with custom values', function () {
+    $invoiceDTO = new InvoiceDTO(
+        invoiceID: 'INV-123',
+        type: InvoiceType::AccPay->value,
+        invoiceNumber: '123',
+        reference: 'REF-123',
+        date: '2023-01-01',
+        dueDate: '2023-01-31',
+        status: InvoiceStatus::Submitted->value,
+        lineAmountTypes: InvoiceLineAmountType::Inclusive->value,
+        currencyCode: 'USD',
+        currencyRate: '1.0',
+        subTotal: '100.00',
+        totalTax: '10.00',
+        total: '110.00',
+        contactID: 'CONTACT-123',
+        contact: [['ContactID' => 'CONTACT-123', 'Name' => 'Test Contact']],
+        lineItems: [['Description' => 'Test Item']],
+        payments: [['PaymentID' => 'PAYMENT-123']],
+        creditNotes: [['CreditNoteID' => 'CREDIT-123']],
+        prepayments: [['PrepaymentID' => 'PREPAY-123']],
+        overpayments: [['OverpaymentID' => 'OVERPAY-123']],
+        hasAttachments: true,
+        isDiscounted: true,
+        hasErrors: true
+    );
+
+    expect($invoiceDTO)->toBeInstanceOf(InvoiceDTO::class)
+        ->and($invoiceDTO->invoiceID)->toBe('INV-123')
+        ->and($invoiceDTO->type)->toBe(InvoiceType::AccPay->value)
+        ->and($invoiceDTO->invoiceNumber)->toBe('123')
+        ->and($invoiceDTO->reference)->toBe('REF-123')
+        ->and($invoiceDTO->date)->toBe('2023-01-01')
+        ->and($invoiceDTO->dueDate)->toBe('2023-01-31')
+        ->and($invoiceDTO->status)->toBe(InvoiceStatus::Submitted->value)
+        ->and($invoiceDTO->lineAmountTypes)->toBe(InvoiceLineAmountType::Inclusive->value)
+        ->and($invoiceDTO->currencyCode)->toBe('USD')
+        ->and($invoiceDTO->currencyRate)->toBe('1.0')
+        ->and($invoiceDTO->subTotal)->toBe('100.00')
+        ->and($invoiceDTO->totalTax)->toBe('10.00')
+        ->and($invoiceDTO->total)->toBe('110.00')
+        ->and($invoiceDTO->contactID)->toBe('CONTACT-123')
+        ->and($invoiceDTO->contact)->toBe([['ContactID' => 'CONTACT-123', 'Name' => 'Test Contact']])
+        ->and($invoiceDTO->lineItems)->toBe([['Description' => 'Test Item']])
+        ->and($invoiceDTO->payments)->toBe([['PaymentID' => 'PAYMENT-123']])
+        ->and($invoiceDTO->creditNotes)->toBe([['CreditNoteID' => 'CREDIT-123']])
+        ->and($invoiceDTO->prepayments)->toBe([['PrepaymentID' => 'PREPAY-123']])
+        ->and($invoiceDTO->overpayments)->toBe([['OverpaymentID' => 'OVERPAY-123']])
+        ->and($invoiceDTO->hasAttachments)->toBeTrue()
+        ->and($invoiceDTO->isDiscounted)->toBeTrue()
+        ->and($invoiceDTO->hasErrors)->toBeTrue();
+});
+
+test('createLineItem static method returns correct array with all values', function () {
+    $lineItem = InvoiceDTO::createLineItem(
+        description: 'Test Item',
+        quantity: 2,
+        unitAmount: 10.50,
+        accountCode: 123,
+        itemCode: 'ITEM-123',
+        taxType: 'OUTPUT',
+        taxAmount: '2.10',
+        lineAmount: '21.00',
+        discountRate: '10',
+        tracking: [['Name' => 'Region', 'Option' => 'North']]
+    );
+
+    expect($lineItem)->toBe([
+        'Description' => 'Test Item',
+        'Quantity' => 2,
+        'UnitAmount' => 10.50,
+        'AccountCode' => 123,
+        'ItemCode' => 'ITEM-123',
+        'TaxType' => 'OUTPUT',
+        'TaxAmount' => '2.10',
+        'LineAmount' => '21.00',
+        'DiscountRate' => '10',
+        'Tracking' => [['Name' => 'Region', 'Option' => 'North']],
+    ]);
+});
+
+test('createLineItem static method filters out null values', function () {
+    $lineItem = InvoiceDTO::createLineItem(
+        description: 'Test Item',
+        quantity: 2,
+        unitAmount: 10.50,
+        accountCode: null,
+        itemCode: null
+    );
+
+    expect($lineItem)->toBe([
+        'Description' => 'Test Item',
+        'Quantity' => 2,
+        'UnitAmount' => 10.50,
+    ]);
+});
+
+test('createLineItem accepts string values for numeric fields', function () {
+    $lineItem = InvoiceDTO::createLineItem(
+        description: 'Test Item',
+        quantity: '2',
+        unitAmount: '10.50'
+    );
+
+    expect($lineItem)->toBe([
+        'Description' => 'Test Item',
+        'Quantity' => '2',
+        'UnitAmount' => '10.50',
+    ]);
+});
+
+test('toArray method returns correct array structure', function () {
+    $invoiceDTO = new InvoiceDTO(
+        type: InvoiceType::AccRec->value,
+        invoiceNumber: '123',
+        date: '2023-01-01',
+        dueDate: '2023-01-31',
+        status: InvoiceStatus::Draft->value,
+        contactID: 'CONTACT-123',
+        lineItems: [
+            InvoiceDTO::createLineItem(
+                description: 'Test Item',
+                quantity: 2,
+                unitAmount: 10.50
+            ),
+        ]
+    );
+
+    $array = $invoiceDTO->toArray();
+
+    expect($array)->toBeArray()
+        ->and($array)->toHaveKey('Type', InvoiceType::AccRec->value)
+        ->and($array)->toHaveKey('InvoiceNumber', '123')
+        ->and($array)->toHaveKey('Date', '2023-01-01')
+        ->and($array)->toHaveKey('DueDate', '2023-01-31')
+        ->and($array)->toHaveKey('Status', InvoiceStatus::Draft->value)
+        ->and($array)->toHaveKey('LineAmountTypes', InvoiceLineAmountType::Exclusive->value)
+        ->and($array)->toHaveKey('Contact')
+        ->and($array['Contact'])->toBe(['ContactID' => 'CONTACT-123'])
+        ->and($array)->toHaveKey('LineItems')
+        ->and($array['LineItems'][0])->toHaveKey('Description', 'Test Item')
+        ->and($array['LineItems'][0])->toHaveKey('Quantity', 2)
+        ->and($array['LineItems'][0])->toHaveKey('UnitAmount', 10.50);
+});
+
+test('toArray method uses contact array when contactID is null', function () {
+    $invoiceDTO = new InvoiceDTO(
+        contact: [
+            'ContactID' => 'CONTACT-123',
+            'Name' => 'Test Contact',
+        ]
+    );
+
+    $array = $invoiceDTO->toArray();
+
+    expect($array)->toHaveKey('Contact')
+        ->and($array['Contact'])->toBe([
+            'ContactID' => 'CONTACT-123',
+            'Name' => 'Test Contact',
+        ]);
+});
+
+test('toArray method filters out null and empty array values', function () {
+    $invoiceDTO = new InvoiceDTO(
+        invoiceNumber: '123',
+        reference: null,
+        lineItems: []
+    );
+
+    $array = $invoiceDTO->toArray();
+
+    expect($array)->toHaveKey('InvoiceNumber')
+        ->and($array)->toHaveKey('Type')
+        ->and($array)->toHaveKey('Status')
+        ->and($array)->toHaveKey('LineAmountTypes')
+        ->and($array)->not->toHaveKey('Reference')
+        ->and($array)->not->toHaveKey('LineItems');
+});

--- a/tests/Enums/ContactStatusTest.php
+++ b/tests/Enums/ContactStatusTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\Enums\ContactStatus;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+test('a valid option returns true', function () {
+    assertTrue(ContactStatus::isValid('ACTIVE'));
+    assertTrue(ContactStatus::isValid('ARCHIVED'));
+    assertTrue(ContactStatus::isValid('GDPRREQUEST'));
+});
+
+test('an invalid option returns false', function () {
+    assertFalse(ContactStatus::isValid('bogus'));
+});

--- a/tests/Enums/InvoiceLineAmountTypeTest.php
+++ b/tests/Enums/InvoiceLineAmountTypeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\Enums\InvoiceLineAmountType;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+test('a valid option returns true', function () {
+    assertTrue(InvoiceLineAmountType::isValid('Exclusive'));
+    assertTrue(InvoiceLineAmountType::isValid('Inclusive'));
+    assertTrue(InvoiceLineAmountType::isValid('NoTax'));
+});
+
+test('an invalid option returns false', function () {
+    assertFalse(InvoiceLineAmountType::isValid('bogus'));
+});

--- a/tests/Enums/InvoiceStatusTest.php
+++ b/tests/Enums/InvoiceStatusTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\Enums\InvoiceStatus;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+test('a valid option returns true', function () {
+    assertTrue(InvoiceStatus::isValid('AUTHORISED'));
+    assertTrue(InvoiceStatus::isValid('DELETED'));
+    assertTrue(InvoiceStatus::isValid('DRAFT'));
+    assertTrue(InvoiceStatus::isValid('PAID'));
+    assertTrue(InvoiceStatus::isValid('SUBMITTED'));
+    assertTrue(InvoiceStatus::isValid('VOIDED'));
+});
+
+test('an invalid option returns false', function () {
+    assertFalse(InvoiceStatus::isValid('bogus'));
+});

--- a/tests/Enums/InvoiceTypeTest.php
+++ b/tests/Enums/InvoiceTypeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\Enums\InvoiceType;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+test('a valid option returns true', function () {
+    assertTrue(InvoiceType::isValid('ACCPAY'));
+    assertTrue(InvoiceType::isValid('ACCREC'));
+});
+
+test('an invalid option returns false', function () {
+    assertFalse(InvoiceType::isValid('bogus'));
+});


### PR DESCRIPTION
This pull request introduces two new Data Transfer Objects (DTOs) for managing `Contact` and `Invoice` data, along with several supporting enums and test cases. The changes aim to enhance the structure, validation, and usability of the codebase for interacting with the Xero API.

### New DTO Classes:
* **`ContactDTO`**: Implements a structured representation of contact data, including methods for creating address, phone, and contact person arrays, and a `toArray` method for API compatibility.
* **`InvoiceDTO`**: Provides a structured representation of invoice data, including a method to create line items and a `toArray` method for API compatibility.

### Supporting Enums:
* **`ContactStatus`**: Defines valid statuses for a contact (`Active`, `Archived`, `GDPRRequest`) with a validation method.
* **`InvoiceLineAmountType`**: Defines valid line amount types for invoices (`Exclusive`, `Inclusive`, `NoTax`) with a validation method.
* **`InvoiceStatus`**: Defines valid statuses for invoices (`Authorised`, `Deleted`, `Draft`, etc.) with a validation method.
* **`InvoiceType`**: Defines valid invoice types (`AccPay`, `AccRec`) with a validation method.

### Enum Refactor:
* **`FilterOptions`**: Renamed enum cases to use PascalCase for consistency with other enums.

### Tests:
* Added comprehensive test cases for `ContactDTO` to validate default and custom instantiation, static methods (`createAddress`, `createPhone`, `createContactPerson`), and the `toArray` method.