### PR TITLE
Allow tenant name to be nullable in getTenantName method

### DIFF
--- a/src/Resources/Invoices.php
+++ b/src/Resources/Invoices.php
@@ -69,7 +69,7 @@ class Invoices extends Xero
 
     public function attachment(string $invoiceId, ?string $attachmentId = null, ?string $fileName = null): string
     {
-        // Depending on the application we may want to get it by the FileName instead fo the AttachmentId
+        // Depending on the application, we may want to get it by the FileName instead of the AttachmentId
         $nameOrId = $attachmentId ? $attachmentId : $fileName;
 
         $result = parent::get('Invoices/'.$invoiceId.'/Attachments/'.$nameOrId);

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -304,7 +304,7 @@ class Xero
         return $token->tenant_id;
     }
 
-    public function getTenantName(): string
+    public function getTenantName(): ?string
     {
         // use id if passed otherwise use logged-in user
         $token = $this->getTokenData();


### PR DESCRIPTION
This pull request includes two changes aimed at improving code quality and functionality in the `Invoices` and `Xero` resources. The most important changes involve fixing a comment typo and updating the return type of a method to better reflect its behavior.

### Code quality improvements:
* Fixed a typo in a comment in the `attachment` method in `src/Resources/Invoices.php`. The word "fo" was corrected to "of" to improve clarity.

### Functional improvements:
* Updated the return type of the `getTenantName` method in `src/Xero.php` from `string` to `?string` to allow for nullable values, aligning the method's behavior with its implementation.