### PR TITLE
Refactor Xero class: remove date formatting and query string methods …

### DIFF
--- a/src/Traits/XeroHelpersTrait.php
+++ b/src/Traits/XeroHelpersTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\Traits;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+use Dcblogdev\Xero\Actions\formatQueryStringsAction;
+use Throwable;
+
+trait XeroHelpersTrait
+{
+    /**
+     * Parse a date string into a formatted date.
+     */
+    public static function formatDate(string $date, string $format = 'Y-m-d H:i:s'): string
+    {
+        try {
+            // Match a Microsoft JSON date format: /Date(1663257600000+0100)/
+            if (preg_match('#^/Date\((\d+)([+-]\d{4})\)/$#', $date, $matches)) {
+                $timestamp = (int) $matches[1] / 1000;
+                $offset = $matches[2];
+                $tzOffset = mb_substr($offset, 0, 3).':'.mb_substr($offset, 3);
+
+                $dt = new DateTimeImmutable("@$timestamp");
+                $dt->setTimezone(new DateTimeZone($tzOffset));
+
+                return $dt->format($format);
+            }
+
+            // Fallback to default DateTime parsing
+            $dt = new DateTimeImmutable($date);
+
+            return $dt->format($format);
+
+        } catch (Throwable $e) {
+            // Invalid date input, return empty string instead of crashing
+            return '';
+        }
+    }
+
+    /**
+     * Format query strings for API requests.
+     */
+    public static function formatQueryStrings(array $params): string
+    {
+        return app(formatQueryStringsAction::class)($params);
+    }
+}


### PR DESCRIPTION
This pull request refactors the `Xero` class by extracting helper methods into a new `XeroHelpersTrait`, improving code organization and reusability. The most notable changes include the creation of the `XeroHelpersTrait`, the removal of duplicate methods from the `Xero` class, and the adoption of the trait in the `Xero` class.

### Code organization and reusability improvements:

* **New `XeroHelpersTrait` created**: Introduced a new trait, `XeroHelpersTrait`, containing two static helper methods: `formatDate` for parsing and formatting date strings, and `formatQueryStrings` for formatting query strings. This consolidates utility functions into a reusable trait. (`src/Traits/XeroHelpersTrait.php`)

* **Trait usage in `Xero` class**: Added the `XeroHelpersTrait` to the `Xero` class, enabling the use of the helper methods defined in the trait. (`src/Xero.php`)

### Code cleanup:

* **Removed duplicate `formatDate` method**: The `formatDate` method was removed from the `Xero` class since it is now part of the `XeroHelpersTrait`. (`src/Xero.php`)

* **Removed duplicate `formatQueryStrings` method**: The `formatQueryStrings` method was removed from the `Xero` class for the same reason. (`src/Xero.php`)

* **Minor comment improvement**: Updated a comment in the `redirectIfNoToken` method for clarity. (`src/Xero.php`)…to a trait