### PR TITLE
Add XeroShowAllTokensCommand and update service provider

### DIFF
--- a/src/Console/Commands/XeroShowAllTokensCommand.php
+++ b/src/Console/Commands/XeroShowAllTokensCommand.php
@@ -9,14 +9,14 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Support\Facades\Crypt;
 
-class XeroShowAllCommand extends Command
+class XeroShowAllTokensCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'xero:show-all';
+    protected $signature = 'xero:show-all-tokens';
 
     /**
      * The console command description.

--- a/src/XeroServiceProvider.php
+++ b/src/XeroServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Dcblogdev\Xero;
 
 use Dcblogdev\Xero\Console\Commands\XeroKeepAliveCommand;
+use Dcblogdev\Xero\Console\Commands\XeroShowAllTokensCommand;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,6 +30,7 @@ class XeroServiceProvider extends ServiceProvider
 
         $this->commands([
             XeroKeepAliveCommand::class,
+            XeroShowAllTokensCommand::class
         ]);
     }
 

--- a/tests/Console/Commands/XeroShowAllTokensCommandTest.php
+++ b/tests/Console/Commands/XeroShowAllTokensCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Dcblogdev\Xero\Console\Commands\XeroShowAllCommand;
+use Dcblogdev\Xero\Console\Commands\XeroShowAllTokensCommand;
 use Dcblogdev\Xero\Models\XeroToken;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
@@ -10,8 +10,8 @@ use Illuminate\Support\Facades\Crypt;
 
 beforeEach(function () {
     // Register the command
-    $this->app->singleton('command.xero.show-all', fn () => new XeroShowAllCommand());
-    Artisan::registerCommand($this->app->make('command.xero.show-all'));
+    $this->app->singleton('command.xero.show-all-tokens', fn () => new XeroShowAllTokensCommand());
+    Artisan::registerCommand($this->app->make('command.xero.show-all-tokens'));
 });
 
 test('command displays message when no tokens exist', function () {
@@ -19,7 +19,7 @@ test('command displays message when no tokens exist', function () {
     XeroToken::query()->delete();
 
     // Run the command
-    $this->artisan('xero:show-all')
+    $this->artisan('xero:show-all-tokens')
         ->expectsOutput('All XERO Tokens in storage')
         ->assertExitCode(0);
 });
@@ -32,7 +32,7 @@ test('command displays tokens in table format', function () {
     ]);
 
     // Run the command
-    $this->artisan('xero:show-all')
+    $this->artisan('xero:show-all-tokens')
         ->expectsOutput('All XERO Tokens in storage')
         ->assertExitCode(0);
 
@@ -56,7 +56,7 @@ test('command handles encrypted tokens correctly', function () {
     ]);
 
     // Run the command
-    $this->artisan('xero:show-all')
+    $this->artisan('xero:show-all-tokens')
         ->expectsOutput('All XERO Tokens in storage')
         ->assertExitCode(0);
 
@@ -83,7 +83,7 @@ test('command handles decryption exceptions', function () {
     ]);
 
     // Run the command
-    $this->artisan('xero:show-all')
+    $this->artisan('xero:show-all-tokens')
         ->expectsOutput('All XERO Tokens in storage')
         ->assertExitCode(0);
 


### PR DESCRIPTION
This pull request renames the `XeroShowAllCommand` to `XeroShowAllTokensCommand` across the codebase to better reflect its purpose. The changes include updates to the command signature, references in the service provider, and associated tests.

### Command Renaming:

* Renamed the `XeroShowAllCommand` class to `XeroShowAllTokensCommand` and updated its signature from `xero:show-all` to `xero:show-all-tokens` in `src/Console/Commands/XeroShowAllTokensCommand.php`.

### Service Provider Updates:

* Added the renamed `XeroShowAllTokensCommand` to the list of commands registered in the `XeroServiceProvider`. [[1]](diffhunk://#diff-8e9138868e0c65361bc3245de4fa53db80d38cdb32dfa8696987006b941f35a5R8) [[2]](diffhunk://#diff-8e9138868e0c65361bc3245de4fa53db80d38cdb32dfa8696987006b941f35a5R33)

### Test Updates:

* Updated the test file name from `XeroShowAllCommandTest.php` to `XeroShowAllTokensCommandTest.php` and replaced all references to `XeroShowAllCommand` with `XeroShowAllTokensCommand`. Updated the artisan command calls in tests from `xero:show-all` to `xero:show-all-tokens`. [[1]](diffhunk://#diff-ca94bcced1b35166a0eb8a23f9d6014244d6b8ef69702a8687ad569a4e5bb034L5-R22) [[2]](diffhunk://#diff-ca94bcced1b35166a0eb8a23f9d6014244d6b8ef69702a8687ad569a4e5bb034L35-R35) [[3]](diffhunk://#diff-ca94bcced1b35166a0eb8a23f9d6014244d6b8ef69702a8687ad569a4e5bb034L59-R59) [[4]](diffhunk://#diff-ca94bcced1b35166a0eb8a23f9d6014244d6b8ef69702a8687ad569a4e5bb034L86-R86)