### PR TITLE
Refactor Xero class methods to set tenant ID for resource instances

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -79,22 +79,34 @@ class Xero
 
     public function contacts(): Contacts
     {
-        return new Contacts;
+        $resource = new Contacts;
+        $resource->setTenantId($this->tenant_id);
+
+        return $resource;
     }
 
     public function creditnotes(): CreditNotes
     {
-        return new CreditNotes;
+        $resource = new CreditNotes;
+        $resource->setTenantId($this->tenant_id);
+
+        return $resource;
     }
 
     public function invoices(): Invoices
     {
-        return new Invoices;
+        $resource = new Invoices;
+        $resource->setTenantId($this->tenant_id);
+
+        return $resource;
     }
 
     public function webhooks(): Webhooks
     {
-        return new Webhooks;
+        $resource = new Webhooks;
+        $resource->setTenantId($this->tenant_id);
+
+        return $resource;
     }
 
     public function isTokenValid(): bool


### PR DESCRIPTION
Updated Xero factory methods to inject the current tenant_id into each resource instance created (Contacts, CreditNotes, Invoices, Webhooks). This ensures resources are tenant-aware without requiring callers to set the tenant manually.

Replaced direct returns of new resource instances with a pattern that:

1. Instantiates the resource
2. Calls setTenantId($this->tenant_id)
3. Returns the configured instance

Impact: Prevents missing tenant configuration on resource usage, reducing potential bugs in multi-tenant contexts.