### PR TITLE
Add retry logic to HTTP requests in Xero class to handle connection a…

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -16,6 +16,7 @@ use Dcblogdev\Xero\Traits\XeroHelpersTrait;
 use Exception;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
@@ -357,7 +358,8 @@ class Xero
         }
 
         try {
-            $response = Http::withToken($this->getAccessToken())
+            $response = Http::retry([200, 500, 1000], fn ($exception) => $exception instanceof ConnectionException || ($exception instanceof RequestException && $exception->response->serverError()))
+                ->withToken($this->getAccessToken())
                 ->withHeaders(array_merge(['Xero-tenant-id' => $this->getTenantId()], $headers))
                 ->accept($accept)
                 ->$type(self::$baseUrl.$request, $data)


### PR DESCRIPTION
This pull request introduces improved error handling for HTTP requests made to the Xero API. The main change is the addition of a retry mechanism that helps handle transient network and server errors more gracefully.

**HTTP Request Reliability Improvements:**

* Added `ConnectionException` import to support new retry logic in `Xero.php`.
* Updated the `guzzle` method to use `Http::retry` with custom logic: retries are triggered for connection errors and server errors, improving resilience against temporary failures when communicating with the Xero API