### PR TITLE
Add PurchaseOrders resource

### DIFF
--- a/src/Resources/PurchaseOrders.php
+++ b/src/Resources/PurchaseOrders.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dcblogdev\Xero\Resources;
+
+use Dcblogdev\Xero\Enums\FilterOptions;
+use Dcblogdev\Xero\Xero;
+use InvalidArgumentException;
+
+class PurchaseOrders extends Xero
+{
+    protected array $queryString = [];
+
+    public function filter(string $key, string|int $value): static
+    {
+        if (! FilterOptions::isValid($key)) {
+            throw new InvalidArgumentException("Filter option '$key' is not valid.");
+        }
+
+        $this->queryString[$key] = $value;
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        $queryString = $this->formatQueryStrings($this->queryString);
+
+        $result = parent::get('PurchaseOrders?'.$queryString);
+
+        if ($this->returnFullResponse) {
+            return $result['body'];
+        }
+
+        return $result['body']['PurchaseOrders'];
+    }
+
+    public function find(string $purchaseOrderId): array
+    {
+        $result = parent::get('PurchaseOrders/'.$purchaseOrderId);
+
+        return $result['body']['PurchaseOrders'][0];
+    }
+
+    public function update(string $purchaseOrderId, array $data): array
+    {
+        $result = $this->post('PurchaseOrders/'.$purchaseOrderId, $data);
+
+        return $result['body']['PurchaseOrders'][0];
+    }
+
+    public function store(array $data): array
+    {
+        $result = $this->post('PurchaseOrders', $data);
+
+        return $result['body']['PurchaseOrders'][0];
+    }
+}

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -11,6 +11,7 @@ use Dcblogdev\Xero\Resources\Accounts;
 use Dcblogdev\Xero\Resources\Contacts;
 use Dcblogdev\Xero\Resources\CreditNotes;
 use Dcblogdev\Xero\Resources\Invoices;
+use Dcblogdev\Xero\Resources\PurchaseOrders;
 use Dcblogdev\Xero\Resources\Webhooks;
 use Dcblogdev\Xero\Traits\XeroHelpersTrait;
 use Exception;
@@ -110,6 +111,14 @@ class Xero
     public function invoices(): Invoices
     {
         $resource = new Invoices;
+        $resource->setTenantId($this->tenant_id);
+
+        return $resource;
+    }
+
+    public function purchaseorders(): PurchaseOrders
+    {
+        $resource = new PurchaseOrders;
         $resource->setTenantId($this->tenant_id);
 
         return $resource;

--- a/tests/Resources/PurchaseOrdersTest.php
+++ b/tests/Resources/PurchaseOrdersTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use Dcblogdev\Xero\Facades\Xero;
+use Dcblogdev\Xero\Models\XeroToken;
+use Dcblogdev\Xero\Resources\PurchaseOrders;
+use Illuminate\Support\Facades\Http;
+
+test('invalid filter option throws exception', function () {
+    Xero::purchaseorders()
+        ->filter('bogus', 1)
+        ->get();
+})->throws(InvalidArgumentException::class, "Filter option 'bogus' is not valid.");
+
+test('filter returns object', function () {
+
+    $filter = (new PurchaseOrders)->filter('ids', '1234');
+
+    expect($filter)->toBeObject();
+});
+
+test('get returns only purchase orders array by default', function () {
+    Http::fake([
+        'api.xero.com/api.xro/2.0/PurchaseOrders*' => Http::response([
+            'Id' => 'test-id',
+            'Status' => 'OK',
+            'ProviderName' => 'Test Provider',
+            'DateTimeUTC' => '/Date(1234567890)/',
+            'PurchaseOrders' => [
+                ['PurchaseOrderID' => '1', 'PurchaseOrderNumber' => 'PO-001'],
+                ['PurchaseOrderID' => '2', 'PurchaseOrderNumber' => 'PO-002'],
+            ],
+        ], 200),
+    ]);
+
+    XeroToken::create([
+        'id' => 0,
+        'access_token' => '1234',
+        'expires_in' => now()->addMinutes(25),
+        'scopes' => 'accounting.transactions',
+        'tenant_id' => 'test-tenant',
+    ]);
+
+    $result = Xero::purchaseorders()->get();
+
+    expect($result)->toBeArray()
+        ->and($result)->toHaveCount(2)
+        ->and($result[0])->toHaveKey('PurchaseOrderID')
+        ->and($result)->not->toHaveKey('Id')
+        ->and($result)->not->toHaveKey('Status');
+});
+
+test('get returns full response body when withFullResponse is called', function () {
+    Http::fake([
+        'api.xero.com/api.xro/2.0/PurchaseOrders*' => Http::response([
+            'Id' => 'test-id',
+            'Status' => 'OK',
+            'ProviderName' => 'Test Provider',
+            'DateTimeUTC' => '/Date(1234567890)/',
+            'PurchaseOrders' => [
+                ['PurchaseOrderID' => '1', 'PurchaseOrderNumber' => 'PO-001'],
+                ['PurchaseOrderID' => '2', 'PurchaseOrderNumber' => 'PO-002'],
+            ],
+        ], 200),
+    ]);
+
+    XeroToken::create([
+        'id' => 0,
+        'access_token' => '1234',
+        'expires_in' => now()->addMinutes(25),
+        'scopes' => 'accounting.transactions',
+        'tenant_id' => 'test-tenant',
+    ]);
+
+    $result = Xero::purchaseorders()->withFullResponse()->get();
+
+    expect($result)->toBeArray()
+        ->and($result)->toHaveKey('Id')
+        ->and($result)->toHaveKey('Status')
+        ->and($result)->toHaveKey('ProviderName')
+        ->and($result)->toHaveKey('DateTimeUTC')
+        ->and($result)->toHaveKey('PurchaseOrders')
+        ->and($result['Id'])->toBe('test-id')
+        ->and($result['Status'])->toBe('OK')
+        ->and($result['PurchaseOrders'])->toBeArray()
+        ->and($result['PurchaseOrders'])->toHaveCount(2);
+});
+
+test('find returns purchase order', function () {
+    $purchaseOrderId = 'purchase-order-id';
+
+    Http::fake([
+        'api.xero.com/api.xro/2.0/PurchaseOrders/'.$purchaseOrderId => Http::response([
+            'PurchaseOrders' => [
+                ['PurchaseOrderID' => $purchaseOrderId, 'PurchaseOrderNumber' => 'PO-001'],
+            ],
+        ], 200),
+    ]);
+
+    XeroToken::create([
+        'id' => 0,
+        'access_token' => '1234',
+        'expires_in' => now()->addMinutes(25),
+        'scopes' => 'accounting.transactions',
+        'tenant_id' => 'test-tenant',
+    ]);
+
+    $result = Xero::purchaseorders()->find($purchaseOrderId);
+
+    expect($result)->toBeArray()
+        ->and($result['PurchaseOrderID'])->toBe($purchaseOrderId);
+});
+
+test('store returns purchase order', function () {
+    Http::fake([
+        'api.xero.com/api.xro/2.0/PurchaseOrders' => Http::response([
+            'PurchaseOrders' => [
+                ['PurchaseOrderID' => 'purchase-order-id', 'PurchaseOrderNumber' => 'PO-001'],
+            ],
+        ], 200),
+    ]);
+
+    XeroToken::create([
+        'id' => 0,
+        'access_token' => '1234',
+        'expires_in' => now()->addMinutes(25),
+        'scopes' => 'accounting.transactions',
+        'tenant_id' => 'test-tenant',
+    ]);
+
+    $result = Xero::purchaseorders()->store([
+        'Contact' => ['ContactID' => 'contact-id'],
+        'LineItems' => [],
+    ]);
+
+    expect($result)->toBeArray()
+        ->and($result['PurchaseOrderID'])->toBe('purchase-order-id');
+});
+
+test('update returns purchase order', function () {
+    $purchaseOrderId = 'purchase-order-id';
+
+    Http::fake([
+        'api.xero.com/api.xro/2.0/PurchaseOrders/'.$purchaseOrderId => Http::response([
+            'PurchaseOrders' => [
+                ['PurchaseOrderID' => $purchaseOrderId, 'PurchaseOrderNumber' => 'PO-001'],
+            ],
+        ], 200),
+    ]);
+
+    XeroToken::create([
+        'id' => 0,
+        'access_token' => '1234',
+        'expires_in' => now()->addMinutes(25),
+        'scopes' => 'accounting.transactions',
+        'tenant_id' => 'test-tenant',
+    ]);
+
+    $result = Xero::purchaseorders()->update($purchaseOrderId, [
+        'Status' => 'AUTHORISED',
+    ]);
+
+    expect($result)->toBeArray()
+        ->and($result['PurchaseOrderID'])->toBe($purchaseOrderId);
+});
+
+test('withFullResponse returns self for fluent chaining', function () {
+    $purchaseOrders = new PurchaseOrders;
+
+    $result = $purchaseOrders->withFullResponse();
+
+    expect($result)->toBeInstanceOf(PurchaseOrders::class)
+        ->and($result)->toBe($purchaseOrders);
+});


### PR DESCRIPTION
When using this package I've found the higher-level `Contacts`, `Invoices` (etc) resources to be really helpful so I don't need to use the lower-level API calls (and dealing with their response bodies).  I use `PurchaseOrders` quite a bit and it's the main Xero model I use that is missing a resource, hope you'd consider adding it!

## Summary

Adds a high-level `purchaseorders()` resource matching the existing `Contacts`, `Invoices`, and `CreditNotes` resource APIs.

Includes support for:
- `filter()`
- `get()`
- `find()`
- `store()`
- `update()`
- `withFullResponse()`

This allows consumers to work with Xero purchase orders without dropping down to lower-level endpoint calls.

## Tests

- Added `tests/Resources/PurchaseOrdersTest.php`
- `php vendor/bin/pint --test src/Xero.php src/Resources/PurchaseOrders.php tests/Resources/PurchaseOrdersTest.php`
- `php vendor/bin/phpstan analyse src/Resources/PurchaseOrders.php tests/Resources/PurchaseOrdersTest.php`
- `php vendor/bin/pest tests/Resources`
